### PR TITLE
More filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,6 @@ A simple tutorial: https://www.youtube.com/watch?v=CNNCCgDkt5k
 
 Untrusted Types works by logging DOM manipulations that could lead to XSS. Simply open DevTools and start debugging. It supports two types of sink discovery.
 
-### Settings
-
-Edit the `settings.json` file to change the options.
-
-```json
-{
-    "keyword" : "d0mxss", // String to be inserted on sources, sinks that contain this string will be highlighted.
-    "traceLimit" : 9999, // If a sink passes by more than 'traceLimit' functions, it will not be logged. Default is no limit.
-    "onlyLogHighlighted" : false, // Only show highlighted sinks.
-    "ignored" : [] ,  // List of strings of files/domains to be ignored, if a sink pass by one of them it will not log.
-    "ignoredIfFirst" : [] // List of strings of files/domains to be ignored ONLY IF is on the first function of the trace.
-}
-```
 
 ### Sinks -> Sources
 
@@ -42,6 +29,18 @@ This is useful when there are too many sinks but few sources. Insert the keyword
 Additionally, you can change the keyword and configure whether to only show highlighted sinks in content.js.
 
 ![](https://github.com/filedescriptor/untrusted-types/blob/main/sources_to_sinks.png)
+
+### Settings
+
+Edit the `settings.json` file to change the options. No need to reload the extension.
+
+Name|Default value|Description
+----|-------------|-----------
+keyword|d0mxss|String to be inserted on sources, sinks that contain this string will be highlighted.
+traceLimit|9999|If a sink passes by more than 'traceLimit'-functions, it will not be logged. Default is no limit.
+onlyLogHighlighted|false|Only show highlighted sinks.
+ignored|[]|List of strings of files/domains to be ignored, if a sink pass by one of them it will not be logged.
+ignoredIfFirst|[]|List of strings of files/domains to be ignored ONLY IF is the source of the sink.
 
 ## Limitation & Known Issues
 1. While it covers a majority of sinks, it doesn't cover navigation sinks like `location = user_input` unless it's `location = 'javascript:' + user_input`. 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@ Untrusted Types is a Chrome extension that abuses [Trusted Types](https://w3c.gi
 
 A simple tutorial: https://www.youtube.com/watch?v=CNNCCgDkt5k
 
-## TODO - FORK :
-
-[] Filter domain
-[X] Trace limit
-[] Filter js file
-
 ## Installation
 
 1. Download this repo
@@ -20,6 +14,20 @@ A simple tutorial: https://www.youtube.com/watch?v=CNNCCgDkt5k
 ## Usage
 
 Untrusted Types works by logging DOM manipulations that could lead to XSS. Simply open DevTools and start debugging. It supports two types of sink discovery.
+
+### Settings
+
+Edit the `settings.json` file to change the options.
+
+```json
+{
+    "keyword" : "d0mxss", // String to be inserted on sources, sinks that contain this string will be highlighted.
+    "traceLimit" : 9999, // If a sink passes by more than 'traceLimit' functions, it will not be logged. Default is no limit.
+    "onlyLogHighlighted" : false, // Only show highlighted sinks.
+    "ignored" : [] ,  // List of strings of files/domains to be ignored, if a sink pass by one of them it will not log.
+    "ignoredIfFirst" : [] // List of strings of files/domains to be ignored ONLY IF is on the first function of the trace.
+}
+```
 
 ### Sinks -> Sources
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Untrusted Types is a Chrome extension that abuses [Trusted Types](https://w3c.gi
 
 A simple tutorial: https://www.youtube.com/watch?v=CNNCCgDkt5k
 
+## TODO - FORK :
+
+[] Filter domain
+[X] Trace limit
+[] Filter js file
+
 ## Installation
 
 1. Download this repo

--- a/content.js
+++ b/content.js
@@ -1,6 +1,7 @@
 // chrome.storage is too slow to allow custom options
 // edit the settings here instead
 let keyword = 'd0mxss';
+let trace_limit = -1 ; // -1 = no limit
 let onlyLogHighlighted = false;
 // creating a policy in the content script context will result in Chrome crashing
 // therefore we need to run the code in the website's context
@@ -29,7 +30,12 @@ script.innerHTML = `
             }
             console.trace.apply(console, args);
         } else if (${!onlyLogHighlighted}) {
-            console.trace(location.href + '\\n%c' + sink, 'background: #222; color: #bada55; font-size: 16px', '\\n' + input);
+            e = new Error();
+            trace_n = (e.stack.match(/\\sat\\s/g) || []).length ; // bugged ?
+            console.log(trace_n);
+            if ( trace_n < ${trace_limit} ) {
+						     console.trace(location.href + '\\n%c' + sink, 'background: #222; color: #bada55; font-size: 16px', '\\n' + input);
+						}
         }
         return input;
     }

--- a/content.js
+++ b/content.js
@@ -1,13 +1,19 @@
 // chrome.storage is too slow to allow custom options
-// edit the settings here instead
+// edit the settings on settings.json instead
 
-options = {
-    "keyword" : 'd0mxss',
-    "traceLimit" : 5, // 9999 = no limit
-    "onlyLogHighlighted" : false,
-    "ignoredDomains" : [], // Regex list of domains to ignore
-    "ignoredFiles" : [] // Regex list of files to ignore
-}
+const settingsUrl = chrome.runtime.getURL('settings.json');
+
+// loads the settings.json file, so you don't need to reload the extension with every edit
+var request = new XMLHttpRequest();
+request.open('GET', settingsUrl, false);
+request.send(null);
+
+// keyword = string to be inserted on sources, sinks that contain this string will be highlighted.
+// traceLimit = If a sink passes by more than 'traceLimit' functions, it will not be logged. Default is no limit.
+// onlyLogHighlighted = Only show highlighted sinks.
+// ignored = List of strings of files/domains to be ignored, if a sink pass by one of them it will not log.
+// ignoredIfFirst = List of strings of files/domains to be ignored ONLY IF is on the first function of the trace.
+settings = JSON.parse(request.responseText) ;
 
 // creating a policy in the content script context will result in Chrome crashing
 // therefore we need to run the code in the website's context
@@ -22,23 +28,38 @@ script.innerHTML = `
         _open.apply(window, arguments);
     }
     function log(input, type, sink) {
-        let options = ${JSON.stringify(options)};
-        if (options.keyword && input.includes(options.keyword)) {
-            let highlightedInput = input.replaceAll(options.keyword, '%c$&%c');
+        let settings = ${JSON.stringify(settings)};
+        if (settings.keyword && input.includes(settings.keyword)) {
+            let highlightedInput = input.replaceAll(settings.keyword, '%c$&%c');
             let args = [
                 location.href + '\\n%c' + sink + '\\n%c' + highlightedInput, 
                 'background: red; color: white; font-size: 16px',
                 'background: unset; color: unset; font-size: unset;'
             ];
-            for (let i = 0; i < input.split(options.keyword).length - 1; i++) {
+            for (let i = 0; i < input.split(settings.keyword).length - 1; i++) {
                 args.push('color: red; border: 1px dotted red; background: yellow;');
                 args.push('color: unset; border: reset;background: unset');
             }
             console.trace.apply(console, args);
-        } else if (!options.onlyLogHighlighted) {
+        } else if (!settings.onlyLogHighlighted) {
             e = new Error();
             trace_n = (e.stack.match(/\\sat\\s/g) || []).length ; // bugged ?
-            if ( trace_n < options.traceLimit ) {
+            trace = e.stack.split("\\n") ; 
+            trace_last_line = trace[trace.length-1] ;
+            ignored = false ;
+            for (var i = settings.ignored.length - 1; i >= 0; i--) {
+                if ( e.stack.includes(settings.ignored[i]) ) {
+                    ignored = true ;
+                    break ;
+                }
+            }
+            for (var i = settings.ignoredIfFirst.length - 1; i >= 0; i--) {
+                if ( trace_last_line.includes(settings.ignoredIfFirst[i]) ) {
+                    ignored = true ;
+                    break ;
+                }
+            }
+            if ( trace_n < settings.traceLimit && !ignored ) {
                 console.trace(location.href + '\\n%c' + sink, 'background: #222; color: #bada55; font-size: 16px', '\\n' + input);
             }
         }

--- a/content.js
+++ b/content.js
@@ -1,8 +1,14 @@
 // chrome.storage is too slow to allow custom options
 // edit the settings here instead
-let keyword = 'd0mxss';
-let trace_limit = -1 ; // -1 = no limit
-let onlyLogHighlighted = false;
+
+options = {
+    "keyword" : 'd0mxss',
+    "traceLimit" : 5, // 9999 = no limit
+    "onlyLogHighlighted" : false,
+    "ignoredDomains" : [], // Regex list of domains to ignore
+    "ignoredFiles" : [] // Regex list of files to ignore
+}
+
 // creating a policy in the content script context will result in Chrome crashing
 // therefore we need to run the code in the website's context
 const head = document.createElement('head');
@@ -16,26 +22,25 @@ script.innerHTML = `
         _open.apply(window, arguments);
     }
     function log(input, type, sink) {
-        let keyword = ${JSON.stringify(keyword)};
-        if (keyword && input.includes(keyword)) {
-            let highlightedInput = input.replaceAll(keyword, '%c$&%c');
+        let options = ${JSON.stringify(options)};
+        if (options.keyword && input.includes(options.keyword)) {
+            let highlightedInput = input.replaceAll(options.keyword, '%c$&%c');
             let args = [
                 location.href + '\\n%c' + sink + '\\n%c' + highlightedInput, 
                 'background: red; color: white; font-size: 16px',
                 'background: unset; color: unset; font-size: unset;'
             ];
-            for (let i = 0; i < input.split(keyword).length - 1; i++) {
+            for (let i = 0; i < input.split(options.keyword).length - 1; i++) {
                 args.push('color: red; border: 1px dotted red; background: yellow;');
                 args.push('color: unset; border: reset;background: unset');
             }
             console.trace.apply(console, args);
-        } else if (${!onlyLogHighlighted}) {
+        } else if (!options.onlyLogHighlighted) {
             e = new Error();
             trace_n = (e.stack.match(/\\sat\\s/g) || []).length ; // bugged ?
-            console.log(trace_n);
-            if ( trace_n < ${trace_limit} ) {
-						     console.trace(location.href + '\\n%c' + sink, 'background: #222; color: #bada55; font-size: 16px', '\\n' + input);
-						}
+            if ( trace_n < options.traceLimit ) {
+                console.trace(location.href + '\\n%c' + sink, 'background: #222; color: #bada55; font-size: 16px', '\\n' + input);
+            }
         }
         return input;
     }

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,9 @@
         "http://*/*",
         "https://*/*"
     ],
+    "web_accessible_resources" : [
+        "settings.json"
+    ],
     "content_scripts": [{
         "matches": [
             "http://*/*",

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,7 @@
+{
+    "keyword" : "d0mxss",
+    "traceLimit" : 9999,
+    "onlyLogHighlighted" : false,
+    "ignored" : [] , 
+    "ignoredIfFirst" : []
+}


### PR DESCRIPTION
Hello @filedescriptor! Amazing tool!

I've been using it for the past couple weeks and notice that would be nice if the tool had more filtering options.
For example, many times a website I'm auditing uses some complex framework that calls more than 20 functions before reaching the sink. Or the website uses some Google's tracking that I don't care about, and stuff like that.

So I coded those options. The main functionalities are an upper limit of calls before reaching the sink, anything above that limit will not be logged , and two filter lists to ignore sinks that passes or are originated from a domain/file. 

I used a `settings.json` file to store those options, and made a synchronous call to the file as a way of bypass the `chrome.storage` limitation, I don't think this impacts the tool's perfomance. 

I'm more than open to any criticism and you can use the pull as you wish. 

Thanks ^^ 